### PR TITLE
Include vmrunner in requirements

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,9 +1,9 @@
 [requires]
 includeos/[>=0.14.0,include_prerelease=True]@includeos/latest
+vmrunner/[>=0.15.0]@includeos/stable
 
 [build_requires]
 chainloader/[>=0.14.0,include_prerelease=True]@includeos/latest
-vmrunner/[>=0.15.0]@includeos/stable
 vmbuild/[>=0.15.0]@includeos/stable
 
 [generators]


### PR DESCRIPTION
vmrunner was only in `build_requires`, so it wasn't added to the path when running `activate.sh`. This moves vmrunner to the `requires` section instead.

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>