### PR TITLE
fix branch name to match includeos/IncludeOS branch rename

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 
   includeos ? import (builtins.fetchGit {
         url = "https://github.com/includeos/IncludeOS.git";
-        ref = "main"; # Currently using v0.16 pre-release branch
+        ref = "main";
       }) { inherit smp; inherit withCcache; },
 }:
 let

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@
 
   includeos ? import (builtins.fetchGit {
         url = "https://github.com/includeos/IncludeOS.git";
-        ref = "v0.16.0-release"; # Currently using v0.16 pre-release branch
+        ref = "main";
       }) { inherit smp; inherit withCcache; },
 
 }:


### PR DESCRIPTION
`default.nix` was updated in 5bb0f0b, but `shell.nix` was not.

this PR removes outdated comments, and fixes the missing branch anchor.